### PR TITLE
Add FHIR on VistA integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,19 @@ Ports
     * information on connecting found here: `SSH Connections`_
   * 8001: Used for VistALink
 
+FHIR on VistA
+$$$$$$$$$$$$$
+
+The Synthea system now contains both halves of the `FHIR on VistA`_
+system.  The VistA installation has the KIDS build, while the ``fhir``
+service contains the Hapi FHIR implementation.  To access the API,
+visit ``http://localhost:8080/api/metadata``.
+
+Further exercising of the API can be accessed after a patient is imported into
+VistA.  Using the ``VistA ICN`` value, information on the patient can be reported
+by accessing:
+
+``http://localhost:8080/api/Patient/<icn>``
 
 Shutting down
 #############
@@ -86,3 +99,4 @@ To remove the containers, execute the following command: ``docker-compose down``
 .. _here: https://docs.docker.com/install/
 .. _`SSH Connections`: https://github.com/OSEHRA/docker-vista#roll-and-scroll-access-for-non-cach%C3%A9-installs
 .. _Installer: https://code.osehra.org/files/clients/OSEHRA_VistA/Installer_For_All_Clients/OSEHRA_VISTA_GUI_Demo.msi
+.. _`FHIR on VistA`: https://github.com/OSEHRA/FHIR-on-VistA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@
 version: "3"
 services:
   manager:
-    build: https://github.com/OSEHRA/dhp-synthea-manager.git
+    build:
+      context: https://github.com/OSEHRA/dhp-synthea-manager.git
+      dockerfile: "Dockerfile.compose"
     ports:
       - "8081:80"
     links:
@@ -25,7 +27,9 @@ services:
     networks:
       - synthea
   synservice: 
-    build: https://github.com/OSEHRA/dhp-synthea-service.git
+    build:
+      context: https://github.com/OSEHRA/dhp-synthea-service.git
+      dockerfile: "Dockerfile.compose"
     links:
       - visual
       - vista
@@ -35,8 +39,19 @@ services:
     image: osehra/syntheaviz
     networks:
       - synthea
+  fhir:
+    build:
+       context: https://github.com/OSEHRA/FHIR-on-VistA.git
+       dockerfile: "java-api/Dockerfile.compose"
+    networks:
+      - synthea
+    links:
+      - visual
+      - vista
+    ports:
+      - "8080:8080"
   vista:
-    image: osehra/vehu:201901-syn
+    image: osehra/vehu:201905-syn-fhir
     networks:
       - synthea
     ports:


### PR DESCRIPTION
Update the VistA container used to select the latest VeHU update which
contains the latest Synthea loader in addition to the FHIR on VistA KIDS
build.

Link an instance of the FHIR on VistA repository into the compose file

Switch all built images to use the "Dockerfile.compose" version.