### PR TITLE
Add host port for Visualization and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,24 @@ DHP Synthea Manager
 $$$$$$$$$$$$$$$$$$$
 
 Once the scrolling has stopped, visit http://localhost:8081 to view the 
-"DHP Manager" interface and begin to generate patients.  The user interface provides the ability to set the parameters for patient records generation, filter the generated patient list by diagnosis, visualize the individual patient history, and send the patient record to VistA.
+"DHP Manager" interface and begin to generate patients.  The user interface
+provides the ability to set the parameters for patient records generation,
+filter the generated patient list by diagnosis, visualize the individual patient
+history, and send the patient record to VistA.
 
-Please note that when sending a patient record to VistA, i.e., clicking on the "SEND TO VISTA" link, it may take up to 10 seconds for the import process to complete.  When the import process completes, the VistA EHR will return the patient medical number as indicated in the VISTA ICN field.
+Please note that when sending a patient record to VistA, i.e., clicking on the
+"SEND TO VISTA" link, it may take up to 10 seconds for the import process to
+complete.  When the import process completes, the VistA EHR will return the
+patient medical number as indicated in the VISTA ICN field.
+
+OSEHRA Synthea Visualization
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+The Synthea visualization created by OSEHRA can be reached by visiting
+http://localhost:8082/synthea/synthea_upload.php
+
+The default address for a FHIR server to query is set to the one set up by this
+Docker-Compose script.  More information on that can be found below.
 
 Accessing VistA
 $$$$$$$$$$$$$$$

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     image: osehra/syntheaviz
     networks:
       - synthea
+    ports:
+      - "8082:80"
   fhir:
     build:
        context: https://github.com/OSEHRA/FHIR-on-VistA.git


### PR DESCRIPTION
Add a host port so that you do not have to overwrite the Synthea-based
display to get the FHIR data.

Update the documentation to provide the latest link.